### PR TITLE
Update governing-the-digital-layer.md

### DIFF
--- a/smart-cities/governing-the-digital-layer.md
+++ b/smart-cities/governing-the-digital-layer.md
@@ -9,13 +9,15 @@ description: >-
 
 What makes a smart city smart is the ability to collect data, process and analyze the data, and act on the insights. In Helsinki, open data was used to develop [BlindSquare](http://www.blindsquare.com/), a mobile GPS app that helps blind and visually impaired people navigate the city. This kind of smart city application requires the collection and sharing of multiple sources of data across public and private organizations.   
 
-In order to collect and share data, a smart city adds a "digital layer" on top of the existing city infrastructure. This is similar to how an operating system adds a digital layer of software on top of the physical hardware of a computer. The difference is for a city, the digital layer is not a single thing, but a network of many connected things. The digital layer includes: 
+In order to collect and share data, a smart city adds a "digital layer" to engage existing city infrastructure. This is similar to how an operating system adds a digital layer of software on top of the physical hardware of a computer. The difference is for a city, the digital layer is not a single thing, but a network of many connected things. The digital layer includes: 
 
 * Physical sensors to collect data;
+* Digital services that use data to control other infrastructure e.g. traffic lights;
 * Databases that store the data on servers;
 * Algorithms and code to protect, manage, process, analyze and transform the data; 
-* Maps, visualizations and models that organize and project the data into more useful forms; 
-* [Application Programming Interfaces](https://medium.com/@perrysetgo/what-exactly-is-an-api-69f36968a41f) \(API\) that share specific data subsets for use in third party applications; and 
+* Maps, visualizations and models that organize and project the data into more useful forms;
+* Standards and source code for how to interact with digital services;
+* [Application Programming Interfaces](https://medium.com/@perrysetgo/what-exactly-is-an-api-69f36968a41f) \(API\) that share specific data subsets for use in third party applications both offline and in realtime; and 
 * All of the public and private services that use the data.
 
 There are four reasons governance of the digital layer is needed: protecting against data breaches and misuses; assuring individual and group privacy; advancing equitable distribution of value; and promoting economic competitiveness. 


### PR DESCRIPTION
Although this has been renamed a 'digital' trust the description of the digital layer is almost all about data. I have suggested a number of changes to expand the definition to include digital services.  I have not attempted to propagate the implications through the entire document. I not that the later section on "What is a Civic Data Trust' has a broader scope that cover physical infrastructure, code based and data. 

 What the role of a trust is in managing the digital layer is a separate question. It may not take on all facets of that task given its Quayside and Toronto focus. But the definition should encompass all aspects and be explicit even  if some are not in the Trust's scope e.g. open standards and open source may or may not be part of the mandate. As there has been very limited discussion of the digital architecture of the Quayside project itself, this question has not received the attention it should todate.  More on this topic at this link https://www.thestar.com/news/gta/2018/12/16/who-will-reap-the-benefits-of-quaysides-smart-city-data.html